### PR TITLE
Loki health and data retention

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -222,7 +222,7 @@ services:
             - ./observability/loki/loki-config.yml:/etc/loki/loki-config.yml:ro
             - loki_data:/loki
         healthcheck:
-            test: ['CMD', '/usr/bin/loki', '-version']
+            test: ['CMD', '/usr/bin/loki', '-health']
             interval: 15s
             timeout: 5s
             retries: 10

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -253,7 +253,7 @@ services:
             - ./observability/loki/loki-config.yml:/etc/loki/loki-config.yml:ro
             - loki_data:/loki
         healthcheck:
-            test: ['CMD', '/usr/bin/loki', '-version']
+            test: ['CMD', '/usr/bin/loki', '-health']
             interval: 15s
             timeout: 5s
             retries: 10

--- a/docker/observability/loki/loki-config.yml
+++ b/docker/observability/loki/loki-config.yml
@@ -29,6 +29,7 @@ schema_config:
 limits_config:
     reject_old_samples: true
     reject_old_samples_max_age: 168h # 7 days
+    retention_period: 168h
     ingestion_rate_mb: 10
     ingestion_burst_size_mb: 20
     max_query_series: 500

--- a/docker/preview/docker-compose.preview.yml
+++ b/docker/preview/docker-compose.preview.yml
@@ -251,7 +251,7 @@ services:
             - ../observability/loki/loki-config.yml:/etc/loki/loki-config.yml:ro
             - loki_data:/loki
         healthcheck:
-            test: ['CMD', '/usr/bin/loki', '-version']
+            test: ['CMD', '/usr/bin/loki', '-health']
             interval: 15s
             timeout: 5s
             retries: 10


### PR DESCRIPTION
- **Type of change**

  - [x] 🐛 Bug fix
  - [ ] ✨ New feature
  - [ ] 📚 Documentation update
  - [ ] 🧪 Test improvement
  - [ ] ⚙️ Build or CI change

- **Checklist**
  - [x] My code follows the style guidelines
  - [ ] I added/updated relevant tests
  - [ ] I updated documentation where necessary

**Why these changes?**

This PR addresses two critical Loki configuration issues:

1.  **Loki healthcheck**: The healthcheck in `docker-compose` files was updated from `loki -version` to `loki -health`. The previous check only verified the binary existed, not if the service was ready, causing Promtail to start prematurely. The new `-health` flag properly checks Loki's `/ready` endpoint.
2.  **Loki data retention**: Added `retention_period: 168h` to `limits_config` in `loki-config.yml`. Without this, despite `retention_enabled: true`, Loki would not delete old data, leading to unbounded disk growth. This change enforces the intended 7-day retention.

---