### PR TITLE
fix(komodo): allow periphery proc mount on apparmor hosts

### DIFF
--- a/komodo/core/docker-compose.komodo.yml
+++ b/komodo/core/docker-compose.komodo.yml
@@ -171,7 +171,7 @@ services:
         volumes:
             - ${COMPOSE_KOMODO_DATA_PATH:-/etc/komodo/core/data}/keys:/config/keys
             - /var/run/docker.sock:/var/run/docker.sock
-            - /proc:/proc:ro
+            - /proc:/proc
             - ${PERIPHERY_ROOT_DIRECTORY:-/etc/komodo}:${PERIPHERY_ROOT_DIRECTORY:-/etc/komodo}
         networks:
             - internal

--- a/komodo/periphery/install.sh
+++ b/komodo/periphery/install.sh
@@ -258,7 +258,7 @@ services:
         volumes:
             - keys:/config/keys
             - /var/run/docker.sock:/var/run/docker.sock
-            - /proc:/proc:ro
+            - /proc:/proc
             - ${PERIPHERY_ROOT_DIRECTORY:-/etc/komodo}:${PERIPHERY_ROOT_DIRECTORY:-/etc/komodo}
         networks:
             - production


### PR DESCRIPTION
- **Type of change**

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Tests (add/update tests)
- [ ] 📚 Documentation update
- [x] ⚙️ Build / CI / tooling change
  