### PR TITLE
fix(deep-id): accept numeric seal metadata fields serialized as strings

### DIFF
--- a/packages/deep-id-api/src/resources/seal-metadata/schemas.ts
+++ b/packages/deep-id-api/src/resources/seal-metadata/schemas.ts
@@ -1,17 +1,31 @@
 import { z } from 'zod';
 import type { SealMetadata } from './types.js';
 
+const DECIMAL_STRING = /^-?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/;
+
 /**
- * The SEAL metadata document. Nothing is coerced: a string `scale`, an unknown
- * `schemeType`, or a missing field is a contract violation. Unknown extra
- * fields are tolerated and dropped.
+ * DeepID serializes some numeric fields as strings. Only a plain decimal string
+ * is converted, so everything else still fails against `schema` with its own
+ * message — unlike `z.coerce.number()`, which turns `true` into `1` and `[128]`
+ * into `128` and would hand SEAL a plausible but wrong parameter.
+ */
+function jsonNumber<T extends z.ZodType<number>>(schema: T) {
+  return z.preprocess(
+    (value) => (typeof value === 'string' && DECIMAL_STRING.test(value) ? Number(value) : value),
+    schema,
+  );
+}
+
+/**
+ * The SEAL metadata document. An unknown `schemeType` or a missing field is a
+ * contract violation. Unknown extra fields are tolerated and dropped.
  */
 export const sealMetadataSchema: z.ZodType<SealMetadata> = z.object({
   id: z.string().min(1),
   schemeType: z.literal('ckks'),
-  securityLevel: z.number().int().positive(),
-  polyModulusDegree: z.number().int().positive(),
-  coeffModulusBitSizes: z.array(z.number().int().positive()).min(1),
-  scale: z.number().positive(),
+  securityLevel: jsonNumber(z.number().int().positive()),
+  polyModulusDegree: jsonNumber(z.number().int().positive()),
+  coeffModulusBitSizes: z.array(jsonNumber(z.number().int().positive())).min(1),
+  scale: jsonNumber(z.number().positive()),
   encryptionParameters: z.string().min(1),
 });

--- a/packages/deep-id-api/src/resources/seal-metadata/types.ts
+++ b/packages/deep-id-api/src/resources/seal-metadata/types.ts
@@ -10,7 +10,7 @@ export interface SealMetadata {
   securityLevel: number;
   polyModulusDegree: number;
   coeffModulusBitSizes: number[];
-  /** CKKS scale, e.g. `2 ** 40`. Must arrive as a JSON number — never coerced. */
+  /** CKKS scale, e.g. `2 ** 40`. */
   scale: number;
   /** Serialized SEAL `EncryptionParameters`, sufficient to build an evaluation context. */
   encryptionParameters: string;

--- a/packages/deep-id-api/tests/unit/resources/seal-metadata.api.test.ts
+++ b/packages/deep-id-api/tests/unit/resources/seal-metadata.api.test.ts
@@ -16,6 +16,17 @@ const VALID_METADATA = {
   encryptionParameters: 'c2VyaWFsaXplZC1wYXJhbXM=',
 };
 
+/** The first three are what `z.coerce.number()` would have silently accepted. */
+const NON_NUMERIC_VALUES: [string, unknown][] = [
+  ['a boolean', true],
+  ['a wrapped array', [128]],
+  ['a padded string', ' 128 '],
+  ['an empty string', ''],
+  ['null', null],
+  ['a non-numeric string', 'abc'],
+  ['a string that overflows to Infinity', '1e999'],
+];
+
 function metadataResponse(data: unknown, statusCode = 200) {
   return { statusCode, headers: {}, data };
 }
@@ -118,12 +129,36 @@ describe('getSealMetadata', () => {
     expect(error.issues.some((issue) => issue.path === 'schemeType')).toBe(true);
   });
 
-  it('does not coerce a string scale into a number', async () => {
+  it('accepts numeric fields serialized as decimal strings', async () => {
     const requester = createMockRequester();
-    requester.mockRequest.mockResolvedValue(metadataResponse({ ...VALID_METADATA, scale: '1099511627776' }));
+    requester.mockRequest.mockResolvedValue(
+      metadataResponse({
+        ...VALID_METADATA,
+        securityLevel: '128',
+        polyModulusDegree: '8192',
+        coeffModulusBitSizes: ['60', '40', '60'],
+        scale: '1099511627776',
+      }),
+    );
+
+    await expect(getSealMetadata(requester, METADATA_PATH)).resolves.toEqual(VALID_METADATA);
+  });
+
+  it('accepts an exponent-notation scale', async () => {
+    const requester = createMockRequester();
+    requester.mockRequest.mockResolvedValue(metadataResponse({ ...VALID_METADATA, scale: '1.099511627776e12' }));
+
+    const metadata = await getSealMetadata(requester, METADATA_PATH);
+
+    expect(metadata.scale).toBe(2 ** 40);
+  });
+
+  it.each(NON_NUMERIC_VALUES)('rejects %s where a number is expected', async (_label, securityLevel) => {
+    const requester = createMockRequester();
+    requester.mockRequest.mockResolvedValue(metadataResponse({ ...VALID_METADATA, securityLevel }));
 
     const error = await captureError(() => getSealMetadata(requester, METADATA_PATH));
-    expect(error.issues.some((issue) => issue.path === 'scale')).toBe(true);
+    expect(error.issues.some((issue) => issue.path === 'securityLevel')).toBe(true);
   });
 
   it('rejects a document with a missing field', async () => {


### PR DESCRIPTION
- **Type of change**

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Tests (add/update tests)
- [ ] 📚 Documentation update
- [ ] ⚙️ Build / CI / tooling change
  