### PR TITLE
fix(deep-id): map SEAL security level names to their bit sizes

### DIFF
--- a/packages/deep-id-api/src/resources/seal-metadata/schemas.ts
+++ b/packages/deep-id-api/src/resources/seal-metadata/schemas.ts
@@ -16,6 +16,14 @@ function jsonNumber<T extends z.ZodType<number>>(schema: T) {
   );
 }
 
+/** DeepID reports the security level as a SEAL `sec_level_type` name. */
+const SEC_LEVEL_BITS: Record<string, number> = { tc128: 128, tc192: 192, tc256: 256 };
+
+const securityLevelSchema = z.preprocess(
+  (value) => (typeof value === 'string' ? (SEC_LEVEL_BITS[value.toLowerCase()] ?? value) : value),
+  jsonNumber(z.number().int().positive()),
+);
+
 /**
  * The SEAL metadata document. An unknown `schemeType` or a missing field is a
  * contract violation. Unknown extra fields are tolerated and dropped.
@@ -23,7 +31,7 @@ function jsonNumber<T extends z.ZodType<number>>(schema: T) {
 export const sealMetadataSchema: z.ZodType<SealMetadata> = z.object({
   id: z.string().min(1),
   schemeType: z.literal('ckks'),
-  securityLevel: jsonNumber(z.number().int().positive()),
+  securityLevel: securityLevelSchema,
   polyModulusDegree: jsonNumber(z.number().int().positive()),
   coeffModulusBitSizes: z.array(jsonNumber(z.number().int().positive())).min(1),
   scale: jsonNumber(z.number().positive()),

--- a/packages/deep-id-api/tests/unit/resources/seal-metadata.api.test.ts
+++ b/packages/deep-id-api/tests/unit/resources/seal-metadata.api.test.ts
@@ -144,6 +144,27 @@ describe('getSealMetadata', () => {
     await expect(getSealMetadata(requester, METADATA_PATH)).resolves.toEqual(VALID_METADATA);
   });
 
+  it.each([
+    ['tc128', 128],
+    ['tc192', 192],
+    ['tc256', 256],
+  ])('maps the SEAL security level name %s to %i', async (name, bits) => {
+    const requester = createMockRequester();
+    requester.mockRequest.mockResolvedValue(metadataResponse({ ...VALID_METADATA, securityLevel: name }));
+
+    const metadata = await getSealMetadata(requester, METADATA_PATH);
+
+    expect(metadata.securityLevel).toBe(bits);
+  });
+
+  it('rejects an unknown security level name', async () => {
+    const requester = createMockRequester();
+    requester.mockRequest.mockResolvedValue(metadataResponse({ ...VALID_METADATA, securityLevel: 'tc512' }));
+
+    const error = await captureError(() => getSealMetadata(requester, METADATA_PATH));
+    expect(error.issues.some((issue) => issue.path === 'securityLevel')).toBe(true);
+  });
+
   it('accepts an exponent-notation scale', async () => {
     const requester = createMockRequester();
     requester.mockRequest.mockResolvedValue(metadataResponse({ ...VALID_METADATA, scale: '1.099511627776e12' }));


### PR DESCRIPTION
- **Type of change**

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Tests (add/update tests)
- [ ] 📚 Documentation update
- [ ] ⚙️ Build / CI / tooling change
  